### PR TITLE
Retain item attributes

### DIFF
--- a/easy-box-packer.rb
+++ b/easy-box-packer.rb
@@ -183,11 +183,14 @@ module EasyBoxPacker
       # select rotation with smallest margin
       final = possible_rotations_and_margins.sort_by { |a| a[:margin].sort }.first
       return unless final
-      return {
+      placement = {
         dimensions: final[:rotation],
         position: space[:position],
         weight: item[:weight].to_f
       }
+      # retain optional attributes, i.e. item identifiers, from item to placement
+      item.each { |key, value| placement[key] ||= value }
+      return placement
     end
 
     def break_up_space(space, placement)

--- a/easy-box-packer.rb
+++ b/easy-box-packer.rb
@@ -183,14 +183,11 @@ module EasyBoxPacker
       # select rotation with smallest margin
       final = possible_rotations_and_margins.sort_by { |a| a[:margin].sort }.first
       return unless final
-      placement = {
+      return {
         dimensions: final[:rotation],
         position: space[:position],
         weight: item[:weight].to_f
       }
-      # retain optional attributes, i.e. item identifiers, from item to placement
-      item.each { |key, value| placement[key] ||= value }
-      return placement
     end
 
     def break_up_space(space, placement)

--- a/easy-box-packer.rb
+++ b/easy-box-packer.rb
@@ -7,7 +7,7 @@ module EasyBoxPacker
       items.sort_by { |h| h[:dimensions].sort.reverse }.reverse.each do |item|
         # If the item is just too big for the container lets give up on this
         if item[:weight].to_f > container[:weight_limit].to_f
-          errors << "Item: #{item} is too heavy for container"
+          errors << { item: item, reason: 'too heavy for container' }
           next
         end
 
@@ -49,7 +49,7 @@ module EasyBoxPacker
         # If it can't be placed in this space, then it's just
         # too big for the container and we should abandon hope
         unless placement
-          errors << "Item: #{item} cannot be placed in container"
+          errors << { item: item, reason: 'cannot be placed in container' }
           next
         end
         # Otherwise lets put the item in a new packing

--- a/easy-box-packer_spec.rb
+++ b/easy-box-packer_spec.rb
@@ -106,7 +106,7 @@ describe '.pack' do
         ]
       )
       expect(packings[:packings].length).to eql(1)
-      expect(packings[:errors]).to eql(["Item: {:dimensions=>[40, 10, 34]} cannot be placed in container"])
+      expect(packings[:errors]).to eql([{:item =>{:dimensions=>[40, 10, 34]},:reason=>'cannot be placed in container'}])
     end
 
     it 'case 5' do


### PR DESCRIPTION
Suggesting this change to allow inclusion of custom attributes for items to be retained in final packing results. Purposes include identifying packed items, enabeling additional calculation after packing, etc.